### PR TITLE
Fix %pre script

### DIFF
--- a/cloud-regionsrv.spec
+++ b/cloud-regionsrv.spec
@@ -62,10 +62,10 @@ Generic configuration for the region service
 %make_install
 
 %pre
-if [ ! `grep regionsrv /etc/group 2>&1 /dev/null` ]; then
+if ! grep -q regionsrv /etc/group; then
     /usr/sbin/groupadd --system regionsrv  2> /dev/null
 fi
-if [ ! `grep regionsrv /etc/passwd 2>&1 /dev/null` ]; then
+if ! grep -q regionsrv /etc/passwd; then
     /usr/sbin/useradd -r -g regionsrv -s /bin/false -c "Cloud Region Service" \
         -d /var/lib/regionsrv regionsrv 2> /dev/null || :
 else


### PR DESCRIPTION
During package upgrade `%pre` script produces an error:
```
Additional rpm output:
/var/tmp/rpm-tmp.LqLuKf: line 4: [: Region: binary operator expected
```

It seems this is due to a space in `grep` output:
```
++ grep regionsrv /etc/group /dev/null
+ '[' '!' /etc/group:regionsrv:x:476:regionsrv ']'
++ grep regionsrv /etc/passwd /dev/null
+ '[' '!' /etc/passwd:regionsrv:x:476:476:Cloud Region Service:/var/lib/regionsrv:/bin/false ']'
./test.sh: line 6: [: Region: binary operator expected
```

Switching to checking status codes instead of command output fixes this.