### PR TITLE
Fix destination for generated certificate parts

### DIFF
--- a/cloud-regionsrv.spec
+++ b/cloud-regionsrv.spec
@@ -17,7 +17,7 @@
 #
 
 Name:           cloud-regionsrv
-Version:        8.1.1
+Version:        8.1.2
 Release:        0
 License:        GPL-3.0+
 Summary:        Cloud Environment Region Service

--- a/usr/sbin/genRegionServerCert
+++ b/usr/sbin/genRegionServerCert
@@ -186,8 +186,9 @@ shutil.copy(
     )
 
 for filename in [cert_file, key_file]:
+    part = filename.split('.')[-1]
     source_file = '/root/regionServCert/%s' % filename
-    destination = '/etc/apache2/ssl.crt/%s' % filename
+    destination = '/etc/apache2/ssl.%s/%s' % (part, filename)
     try:
         os.rename(source_file, destination)
     except OSError as err:


### PR DESCRIPTION
... f01dfac placed both key & cert in `ssl.crt` dir, instead of placing the key in `ssl.key` dir.

