### PR TITLE
Use alias region hint

### DIFF
--- a/srv/www/regionService/regionInfo.py
+++ b/srv/www/regionService/regionInfo.py
@@ -49,6 +49,7 @@ smt-fingerprint = SMT_CERT_FINGERPRINT
 
 import configparser
 import getopt
+import glob
 import ipaddress
 import logging
 import os
@@ -290,10 +291,11 @@ def index():
 
     if region_hint:
         region_hint = region_hint.lower()
-        alias = get_region_hint_alias(region_hint)
-        if alias:
-            logging.info('Using alias of %s: %s' % (region_hint, alias))
-            region_hint = alias
+        if AZURE_IP_RANGE_PROC_CFG in glob.glob('/etc/*IPRangeProc.cfg'):
+            alias = get_region_hint_alias(region_hint)
+            if alias:
+                logging.info('Using alias of %s: %s' % (region_hint, alias))
+                region_hint = alias
 
         logging.info('\tRegion hint: %s' % region_hint)
 

--- a/srv/www/regionService/regionInfo.py
+++ b/srv/www/regionService/regionInfo.py
@@ -72,14 +72,11 @@ def get_region_hint_alias(region_hint):
 
     for section in azure_ip_range_cfg.sections():
         comments = None
-        try:
-            if azure_ip_range_cfg.has_option(section, 'comments'):
-                comments = azure_ip_range_cfg.get(
-                    section,
-                    'comments'
-                )
-        except Exception:
-            pass
+        if azure_ip_range_cfg.has_option(section, 'comments'):
+            comments = azure_ip_range_cfg.get(
+                section,
+                'comments'
+            )
         if (
             comments and region_hint and
             (region_hint in comments) and ('alias' in comments)


### PR DESCRIPTION
When using an alias as region hint, the alias
is not present in /etc/regionService/regionData.cfg

However, it is present in /etc/_csp_IPRangeProc.cfg, as

[foo]
smtIPs = ...
smtFPs = ...
dnsNames = ...
comments = alias for bar (ServiceTags)

When 'bar' is sent as a region hint, we use 'foo' as a region hint internally

This fixes bsc#1211359