### PR TITLE
Add clean target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,12 @@ files = Makefile LICENSE README.md
 
 nv = $(shell rpm -q --specfile --qf '%{NAME}-%{VERSION}\n' *.spec | grep -v config)
 
-tar:
+.PHONY: clean tar install coverage
+
+clean:
+	rm -rf tests/helpers/__pycache__ tests/__pycache__ srv/www/regionService/__pycache__
+
+tar: clean
 	mkdir "$(nv)"
 	cp -r $(dirs) $(files) "$(nv)"
 	tar -cjf "$(nv).tar.bz2" "$(nv)"

--- a/cloud-regionsrv.spec
+++ b/cloud-regionsrv.spec
@@ -75,7 +75,8 @@ fi
 
 %files
 %defattr(-,root,root,-)
-%doc LICENSE README.md
+%doc README.md
+%license LICENSE
 %config(noreplace) %{_sysconfdir}/apache2/vhosts.d/regionsrv_vhost.conf
 %config %{_sysconfdir}/logrotate.d/regionInfo.lr
 %attr(755,regionsrv,regionsrv) %dir /srv/www/regionService


### PR DESCRIPTION
Add a clean target to remove testing artifacts. Make the tar target dependent on clean to ensure no Python cache files form the build are propagated into the tar archive.