### PR TITLE
Update cert generation

### DIFF
--- a/cloud-regionsrv.spec
+++ b/cloud-regionsrv.spec
@@ -17,7 +17,7 @@
 #
 
 Name:           cloud-regionsrv
-Version:        8.4.0
+Version:        8.4.1
 Release:        0
 License:        GPL-3.0+
 Summary:        Cloud Environment Region Service

--- a/usr/sbin/genRegionServerCert
+++ b/usr/sbin/genRegionServerCert
@@ -46,7 +46,7 @@ def create_self_signed_cert(cert_dir, cert_file, cert_key, options):
     k = crypto.PKey()
     k.generate_key(crypto.TYPE_RSA, 4096)
 
-    # Figure setting for subjectAltName
+    # Figure out setting for subjectAltName
     template = 'IP:%s'
     try:
         i = ipaddress.ip_address(options.hostname)
@@ -67,6 +67,7 @@ def create_self_signed_cert(cert_dir, cert_file, cert_key, options):
 
     # create a self-signed cert
     cert = crypto.X509()
+    cert.set_version(2) # THis will generate a version 3 certificate
     cert.get_subject().C = options.country
     cert.get_subject().ST = options.state
     cert.get_subject().L = options.location
@@ -164,7 +165,7 @@ if os.path.exists('/etc/apache2/ssl.crt/%s' % cert_file):
 
 if os.path.exists('/etc/apache2/ssl.key/%s' % key_file):
     print('Key for this server already exists, taking no action')
-    print('/etc/apache2/ssl.crt/%s' % key_file)
+    print('/etc/apache2/ssl.key/%s' % key_file)
     sys.exit(1)
 
 if not os.path.exists('/root/regionServCert'):


### PR DESCRIPTION
Set the cert generation to generate a v3 cert. Newer versions of python-requests require v3 certs and we need to make sure region server certs work with python code.